### PR TITLE
Allow logos to be configured

### DIFF
--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -99,10 +99,12 @@ module AccountsHelper
   end
 
   def svg_logo
-    content_tag(:svg, tag(:use, 'xlink:href' => '#decodon-logo'), 'viewBox' => '0 0 216.4144 232.00976')
+    @logo_transparent = InstancePresenter.new.logo_transparent&.file&.url
+    content_tag(:svg, @logo_transparent || tag(:use, 'xlink:href' => '#decodon-logo'), 'viewBox' => '0 0 216.4144 232.00976')
   end
 
   def svg_logo_full
-    content_tag(:svg, tag(:use, 'xlink:href' => '#decodon-logo-full'), 'viewBox' => '0 0 713.35878 175.8678')
+    @logo_full = InstancePresenter.new.logo&.file&.url
+    content_tag(:svg, @logo_full || tag(:use, 'xlink:href' => '#decodon-logo-full'), 'viewBox' => '0 0 713.35878 175.8678')
   end
 end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -100,13 +100,13 @@ module AccountsHelper
 
   def svg_logo
     logo_url = InstancePresenter.new.logo_transparent&.file&.url
-    tag = logo_url.present? ? tag(:use, 'href' => logo_url) : tag(:use, 'xlink:href' => '#decodon-logo')
-    content_tag(:svg, tag, 'viewBox' => '0 0 216.4144 232.00976')
+    tag = logo_url.present? ? tag(:img, 'src' => logo_url) : nil
+    tag || content_tag(:svg, tag(:use, 'xlink:href' => '#decodon-logo'), 'viewBox' => '0 0 216.4144 232.00976')
   end
 
   def svg_logo_full
     logo_url = InstancePresenter.new.logo&.file&.url
-    tag = logo_url.present? ? tag(:use, 'href' => logo_url) : tag(:use, 'xlink:href' => '#decodon-logo-full')
-    content_tag(:svg, tag, 'viewBox' => '0 0 713.35878 175.8678')
+    tag = logo_url.present? ? tag(:img, 'src' => logo_url) : nil
+    tag || content_tag(:svg, tag(:use, 'xlink:href' => '#decodon-logo-full'), 'viewBox' => '0 0 713.35878 175.8678')
   end
 end

--- a/app/helpers/accounts_helper.rb
+++ b/app/helpers/accounts_helper.rb
@@ -99,12 +99,14 @@ module AccountsHelper
   end
 
   def svg_logo
-    @logo_transparent = InstancePresenter.new.logo_transparent&.file&.url
-    content_tag(:svg, @logo_transparent || tag(:use, 'xlink:href' => '#decodon-logo'), 'viewBox' => '0 0 216.4144 232.00976')
+    logo_url = InstancePresenter.new.logo_transparent&.file&.url
+    tag = logo_url.present? ? tag(:use, 'href' => logo_url) : tag(:use, 'xlink:href' => '#decodon-logo')
+    content_tag(:svg, tag, 'viewBox' => '0 0 216.4144 232.00976')
   end
 
   def svg_logo_full
-    @logo_full = InstancePresenter.new.logo&.file&.url
-    content_tag(:svg, @logo_full || tag(:use, 'xlink:href' => '#decodon-logo-full'), 'viewBox' => '0 0 713.35878 175.8678')
+    logo_url = InstancePresenter.new.logo&.file&.url
+    tag = logo_url.present? ? tag(:use, 'href' => logo_url) : tag(:use, 'xlink:href' => '#decodon-logo-full')
+    content_tag(:svg, tag, 'viewBox' => '0 0 713.35878 175.8678')
   end
 end

--- a/app/models/form/admin_settings.rb
+++ b/app/models/form/admin_settings.rb
@@ -29,6 +29,8 @@ class Form::AdminSettings
     hero
     mascot
     email
+    logo
+    logo_transparent
     trends
     trendable_by_default
     show_domain_blocks
@@ -57,6 +59,8 @@ class Form::AdminSettings
     hero
     mascot
     email
+    logo
+    logo_transparent
   ).freeze
 
   attr_accessor(*KEYS)

--- a/app/presenters/instance_presenter.rb
+++ b/app/presenters/instance_presenter.rb
@@ -56,6 +56,14 @@ class InstancePresenter
     @hero ||= Rails.cache.fetch('site_uploads/hero') { SiteUpload.find_by(var: 'hero') }
   end
 
+  def logo
+    @logo ||= Rails.cache.fetch('site_uploads/logo') { SiteUpload.find_by(var: 'logo') }
+  end
+
+  def logo_transparent
+    @logo_transparent ||= Rails.cache.fetch('site_uploads/logo_transparent') { SiteUpload.find_by(var: 'logo_transparent') }
+  end
+
   def mascot
     @mascot ||= Rails.cache.fetch('site_uploads/mascot') { SiteUpload.find_by(var: 'mascot') }
   end

--- a/app/views/admin/settings/edit.html.haml
+++ b/app/views/admin/settings/edit.html.haml
@@ -39,6 +39,12 @@
 
   .fields-row
     .fields-row__column.fields-row__column-6.fields-group
+      = f.input :logo, as: :file, wrapper: :with_block_label, label: t('admin.settings.logo.title'), hint: site_upload_delete_hint(t('admin.settings.logo.desc_html'), :logo)
+    .fields-row__column.fields-row__column-6.fields-group
+      = f.input :logo_transparent, as: :file, wrapper: :with_block_label, label: t('admin.settings.logo_transparent.title'), hint: site_upload_delete_hint(t('admin.settings.logo_transparent.desc_html'), :logo_transparent)
+
+  .fields-row
+    .fields-row__column.fields-row__column-6.fields-group
       = f.input :mascot, as: :file, wrapper: :with_block_label, label: t('admin.settings.mascot.title'), hint: site_upload_delete_hint(t('admin.settings.mascot.desc_html'), :mascot)
     .fields-row__column.fields-row__column-6.fields-group
       = f.input :email, as: :file, wrapper: :with_block_label, label: t('admin.settings.email.title'), hint: site_upload_delete_hint(t('admin.settings.email.desc_html'), :email)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -620,11 +620,17 @@ en:
       hero:
         desc_html: Displayed on the frontpage. At least 600x100px recommended. When not set, falls back to server thumbnail
         title: Hero image
+      logo:
+        desc_html: Displayed at the top of the homepage and other places. SVG format. At least 375x100px recommended. When not set, falls back to decodon logo
+        title: Full logo
+      logo_transparent:
+        desc_html: Displayed in the footer and sidebars. SVG format. At least 150x150px recommended. When not set, falls back to decodon flower
+        title: Small transparent logo
       mascot:
         desc_html: Displayed on multiple pages. At least 293×205px recommended. When not set, falls back to default mascot
         title: Mascot image
       email:
-        desc_html: Displayed on the top of emails. At least 138x34px recommended. When not set, falls back to default Mastodon full logo
+        desc_html: Displayed on the top of emails. At least 138x34px recommended. When not set, falls back to default decodon full logo
         title: Email header image
       peers_api_enabled:
         desc_html: Domain names this server has encountered in the fediverse

--- a/spec/presenters/instance_presenter_spec.rb
+++ b/spec/presenters/instance_presenter_spec.rb
@@ -91,8 +91,8 @@ describe InstancePresenter do
   end
 
   describe '#source_url' do
-    it 'returns "https://github.com/mastodon/mastodon"' do
-      expect(instance_presenter.source_url).to eq('https://github.com/mastodon/mastodon')
+    it 'returns "https://github.com/jesseplusplus/decodon"' do
+      expect(instance_presenter.source_url).to eq('https://github.com/jesseplusplus/decodon')
     end
   end
 
@@ -110,10 +110,31 @@ describe InstancePresenter do
     end
   end
 
+  describe '#logo' do
+    it 'returns SiteUpload' do
+      logo = Fabricate(:site_upload, var: 'logo')
+      expect(instance_presenter.logo).to eq(logo)
+    end
+  end
+
+  describe '#logo_transparent' do
+    it 'returns SiteUpload' do
+      logo_transparent = Fabricate(:site_upload, var: 'logo_transparent')
+      expect(instance_presenter.logo_transparent).to eq(logo_transparent)
+    end
+  end
+
   describe '#mascot' do
     it 'returns SiteUpload' do
       mascot = Fabricate(:site_upload, var: 'mascot')
       expect(instance_presenter.mascot).to eq(mascot)
+    end
+  end
+
+  describe '#email' do
+    it 'returns SiteUpload' do
+      email = Fabricate(:site_upload, var: 'email')
+      expect(instance_presenter.email).to eq(email)
     end
   end
 end


### PR DESCRIPTION
This patch adds admin upload options for setting your own main full logo and small transparent logo on the website.