### PR TITLE
Allow locked accounts to be suggested by staff

### DIFF
--- a/app/models/account_suggestions/setting_source.rb
+++ b/app/models/account_suggestions/setting_source.rb
@@ -25,7 +25,6 @@ class AccountSuggestions::SettingSource < AccountSuggestions::Source
            .followable_by(account)
            .not_excluded_by_account(account)
            .not_domain_blocked_by_account(account)
-           .where(locked: false)
            .where.not(id: account.id)
   end
 

--- a/app/models/account_suggestions/setting_source.rb
+++ b/app/models/account_suggestions/setting_source.rb
@@ -22,6 +22,7 @@ class AccountSuggestions::SettingSource < AccountSuggestions::Source
 
   def scope(account)
     Account.searchable
+           .discoverable
            .followable_by(account)
            .not_excluded_by_account(account)
            .not_domain_blocked_by_account(account)


### PR DESCRIPTION
But also ensure this respects the user's preference for recommendation and excludes them if they do not wish to be suggested.