### PR TITLE
Make media attachments appear first in statuses

### DIFF
--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -530,6 +530,8 @@ class Status extends ImmutablePureComponent {
               </a>
             </div>
 
+            {media}
+
             <StatusContent
               status={status}
               onClick={this.handleClick}
@@ -539,8 +541,6 @@ class Status extends ImmutablePureComponent {
               collapsable
               onCollapsedToggle={this.handleCollapsedToggle}
             />
-
-            {media}
 
             <StatusActionBar scrollKey={scrollKey} status={status} account={account} onFilter={matchedFilters ? this.handleFilterClick : null} {...other} />
           </div>

--- a/app/javascript/mastodon/features/direct_timeline/components/conversation.js
+++ b/app/javascript/mastodon/features/direct_timeline/components/conversation.js
@@ -161,6 +161,13 @@ class Conversation extends ImmutablePureComponent {
               </div>
             </div>
 
+            {lastStatus.get('media_attachments').size > 0 && (
+              <AttachmentList
+                compact
+                media={lastStatus.get('media_attachments')}
+              />
+            )}
+
             <StatusContent
               status={lastStatus}
               onClick={this.handleClick}
@@ -168,13 +175,6 @@ class Conversation extends ImmutablePureComponent {
               onExpandedToggle={this.handleShowMore}
               collapsable
             />
-
-            {lastStatus.get('media_attachments').size > 0 && (
-              <AttachmentList
-                compact
-                media={lastStatus.get('media_attachments')}
-              />
-            )}
 
             <div className='status__action-bar'>
               <IconButton className='status__action-bar-button' title={intl.formatMessage(messages.reply)} icon='reply' onClick={this.handleReply} />

--- a/app/javascript/mastodon/features/report/components/status_check_box.js
+++ b/app/javascript/mastodon/features/report/components/status_check_box.js
@@ -61,8 +61,8 @@ class StatusCheckBox extends React.PureComponent {
           </div>
         </div>
 
-        <StatusContent status={status} />
         <MediaAttachments status={status} />
+        <StatusContent status={status} />
       </div>
     );
 

--- a/app/javascript/mastodon/features/status/components/detailed_status.js
+++ b/app/javascript/mastodon/features/status/components/detailed_status.js
@@ -268,14 +268,14 @@ class DetailedStatus extends ImmutablePureComponent {
             <DisplayName account={status.get('account')} localDomain={this.props.domain} />
           </a>
 
+          {media}
+
           <StatusContent
             status={status}
             expanded={!status.get('hidden')}
             onExpandedToggle={this.handleExpandedToggle}
             onTranslate={this.handleTranslate}
           />
-
-          {media}
 
           <div className='detailed-status__meta'>
             <a className='detailed-status__datetime' href={`/@${status.getIn(['account', 'acct'])}\/${status.get('id')}`} target='_blank' rel='noopener noreferrer'>

--- a/app/javascript/mastodon/features/ui/components/boost_modal.js
+++ b/app/javascript/mastodon/features/ui/components/boost_modal.js
@@ -114,14 +114,14 @@ class BoostModal extends ImmutablePureComponent {
               </a>
             </div>
 
-            <StatusContent status={status} />
-
             {status.get('media_attachments').size > 0 && (
               <AttachmentList
                 compact
                 media={status.get('media_attachments')}
               />
             )}
+
+            <StatusContent status={status} />
           </div>
         </div>
 

--- a/app/javascript/styles/mastodon/components.scss
+++ b/app/javascript/styles/mastodon/components.scss
@@ -829,6 +829,8 @@
   overflow: hidden;
   text-overflow: ellipsis;
   padding-top: 2px;
+  padding-left: 16px;
+  padding-right: 16px;
   color: $primary-text-color;
 
   &:focus {
@@ -1050,7 +1052,8 @@
 }
 
 .status {
-  padding: 16px;
+  padding-top: 16px;
+  padding-bottom: 16px;
   min-height: 54px;
   border-bottom: 1px solid lighten($ui-base-color, 8%);
   cursor: auto;
@@ -1068,6 +1071,7 @@
   .audio-player,
   .attachment-list {
     margin-top: 16px;
+    margin-bottom: 12px;
   }
 
   &.light {
@@ -1163,6 +1167,8 @@
 }
 
 .status__info {
+  padding-left: 16px;
+  padding-right: 16px;
   font-size: 15px;
   margin-bottom: 10px;
   display: flex;
@@ -1198,6 +1204,8 @@
 
   .status__content {
     padding: 0;
+    padding-left: 16px;
+    padding-right: 16px;
     white-space: normal;
   }
 
@@ -1233,6 +1241,8 @@
   align-items: center;
   gap: 18px;
   margin-top: 16px;
+  padding-left: 16px;
+  padding-right: 16px;
 }
 
 .detailed-status__action-bar-dropdown {
@@ -5866,7 +5876,6 @@ a.status-card.compact:hover {
   box-sizing: border-box;
   margin-top: 8px;
   overflow: hidden;
-  border-radius: 4px;
   position: relative;
   width: 100%;
   min-height: 64px;
@@ -5878,7 +5887,6 @@ a.status-card.compact:hover {
   display: block;
   float: left;
   position: relative;
-  border-radius: 4px;
   overflow: hidden;
 
   &.standalone {

--- a/app/views/admin/reports/_status.html.haml
+++ b/app/views/admin/reports/_status.html.haml
@@ -2,6 +2,9 @@
   %label.batch-table__row__select.batch-checkbox
     = f.check_box :status_ids, { multiple: true, include_hidden: false }, status.id
   .batch-table__row__content
+    - unless status.proper.ordered_media_attachments.empty?
+      = render partial: 'admin/reports/media_attachments', locals: { status: status.proper }
+
     .status__content><
       - if status.proper.spoiler_text.blank?
         = prerender_custom_emojis(status_content_format(status.proper), status.proper.emojis)
@@ -10,9 +13,6 @@
           %summary><
             %strong> Content warning: #{prerender_custom_emojis(h(status.proper.spoiler_text), status.proper.emojis)}
           = prerender_custom_emojis(status_content_format(status.proper), status.proper.emojis)
-
-    - unless status.proper.ordered_media_attachments.empty?
-      = render partial: 'admin/reports/media_attachments', locals: { status: status.proper }
 
     .detailed-status__meta
       - if status.application

--- a/app/views/admin/status_edits/_status_edit.html.haml
+++ b/app/views/admin/status_edits/_status_edit.html.haml
@@ -1,4 +1,7 @@
 .status
+  - unless status_edit.ordered_media_attachments.empty?
+    = render partial: 'admin/reports/media_attachments', locals: { status: status_edit }
+
   .status__content><
     - if status_edit.spoiler_text.blank?
       = prerender_custom_emojis(status_content_format(status_edit), status_edit.emojis)
@@ -7,9 +10,6 @@
         %summary><
           %strong> Content warning: #{prerender_custom_emojis(h(status_edit.spoiler_text), status_edit.emojis)}
         = prerender_custom_emojis(status_content_format(status_edit), status_edit.emojis)
-
-  - unless status_edit.ordered_media_attachments.empty?
-    = render partial: 'admin/reports/media_attachments', locals: { status: status_edit }
 
   .detailed-status__meta
     %time.formatted{ datetime: status_edit.created_at.iso8601, title: l(status_edit.created_at) }= l(status_edit.created_at)

--- a/app/views/filters/statuses/_status_filter.html.haml
+++ b/app/views/filters/statuses/_status_filter.html.haml
@@ -4,6 +4,11 @@
   %label.batch-table__row__select.batch-checkbox
     = f.check_box :status_filter_ids, { multiple: true, include_hidden: false }, status_filter.id
   .batch-table__row__content
+    - status.ordered_media_attachments.each do |media_attachment|
+      %abbr{ title: media_attachment.description }
+        = fa_icon 'link'
+        = media_attachment.file_file_name
+
     .status__content><
       - if status.spoiler_text.blank?
         = prerender_custom_emojis(status_content_format(status), status.emojis)
@@ -12,11 +17,6 @@
           %summary><
             %strong> Content warning: #{prerender_custom_emojis(h(status.spoiler_text), status.emojis)}
           = prerender_custom_emojis(status_content_format(status), status.emojis)
-
-    - status.ordered_media_attachments.each do |media_attachment|
-      %abbr{ title: media_attachment.description }
-        = fa_icon 'link'
-        = media_attachment.file_file_name
 
     .detailed-status__meta
       = link_to ActivityPub::TagManager.instance.url_for(status.account), class: 'name-tag', target: '_blank', rel: 'noopener noreferrer' do

--- a/app/views/statuses/_detailed_status.html.haml
+++ b/app/views/statuses/_detailed_status.html.haml
@@ -15,6 +15,13 @@
 
   = account_action_button(status.account)
 
+  - if !status.ordered_media_attachments.empty?
+    - if status.ordered_media_attachments.first.video?
+      = render_video_component(status, width: 670, height: 380, detailed: true)
+    - elsif status.ordered_media_attachments.first.audio?
+      = render_audio_component(status, width: 670, height: 380)
+    - else
+      = render_media_gallery_component(status, height: 380, standalone: true)
   .status__content.emojify{ :data => ({ spoiler: current_account&.user&.setting_expand_spoilers ? 'expanded' : 'folded' } if status.spoiler_text?) }<
     - if status.spoiler_text?
       %p<
@@ -26,14 +33,7 @@
       - if status.preloadable_poll
         = render_poll_component(status)
 
-  - if !status.ordered_media_attachments.empty?
-    - if status.ordered_media_attachments.first.video?
-      = render_video_component(status, width: 670, height: 380, detailed: true)
-    - elsif status.ordered_media_attachments.first.audio?
-      = render_audio_component(status, width: 670, height: 380)
-    - else
-      = render_media_gallery_component(status, height: 380, standalone: true)
-  - elsif status.preview_card
+  - if status.ordered_media_attachments.empty? && status.preview_card
     = render_card_component(status)
 
   .detailed-status__meta

--- a/app/views/statuses/_simple_status.html.haml
+++ b/app/views/statuses/_simple_status.html.haml
@@ -27,6 +27,14 @@
           %span.display-name__account
             = acct(status.account)
             = fa_icon('lock') if status.account.locked?
+
+  - if !status.ordered_media_attachments.empty?
+    - if status.ordered_media_attachments.first.video?
+      = render_video_component(status, width: 610, height: 343)
+    - elsif status.ordered_media_attachments.first.audio?
+      = render_audio_component(status, width: 610, height: 343)
+    - else
+      = render_media_gallery_component(status, height: 343)
   .status__content.emojify{ :data => ({ spoiler: current_account&.user&.setting_expand_spoilers ? 'expanded' : 'folded' } if status.spoiler_text?) }<
     - if status.spoiler_text?
       %p<
@@ -37,15 +45,7 @@
 
       - if status.preloadable_poll
         = render_poll_component(status)
-
-  - if !status.ordered_media_attachments.empty?
-    - if status.ordered_media_attachments.first.video?
-      = render_video_component(status, width: 610, height: 343)
-    - elsif status.ordered_media_attachments.first.audio?
-      = render_audio_component(status, width: 610, height: 343)
-    - else
-      = render_media_gallery_component(status, height: 343)
-  - elsif status.preview_card
+  - if status.ordered_media_attachment_ids.empty? && status.preview_card
     = render_card_component(status)
 
   - if !status.in_reply_to_id.nil? && status.in_reply_to_account_id == status.account.id && !hide_show_thread

--- a/app/views/statuses/show.html.haml
+++ b/app/views/statuses/show.html.haml
@@ -14,7 +14,7 @@
   = opengraph 'og:url', short_account_status_url(@account, @status)
   = opengraph 'og:published_time', @status.created_at.iso8601
 
-  = render 'og_description', activity: @status
   = render 'og_image', activity: @status, account: @account
+  = render 'og_description', activity: @status
 
 = render 'shared/web_app'


### PR DESCRIPTION
Since this fork is media-focused, media should appear first. This PR also tweaks the style to make images take up the full width of the post, like so:

<img width="583" alt="Screenshot 2023-02-21 at 5 22 41 PM" src="https://user-images.githubusercontent.com/382669/220496866-56552316-eb0b-4595-848b-5b8c696b3a57.png">
