### PR TITLE
Remove the option for public or limited posts from everyone except owners

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -89,6 +89,7 @@ class Status < ApplicationRecord
   validates_with DisallowedHashtagsValidator
   validates :reblog, uniqueness: { scope: :account }, if: :reblog?
   validates :visibility, exclusion: { in: %w(direct limited) }, if: :reblog?
+  validates :visibility, inclusion: { in: %w(private mutual direct limited) }, if: -> { account.local? && account.user.role != UserRole.find_by(name: 'Owner') }
 
   accepts_nested_attributes_for :poll
 

--- a/spec/fabricators/status_fabricator.rb
+++ b/spec/fabricators/status_fabricator.rb
@@ -1,6 +1,7 @@
 Fabricator(:status) do
   account
   text "Lorem ipsum dolor sit amet"
+  visibility "private"
 
   after_build do |status|
     status.uri = Faker::Internet.device_token if !status.account.local? && status.uri.nil?


### PR DESCRIPTION
Follow-up to https://github.com/jesseplusplus/decodon/pull/1.

This was previously enforced only in the UI and by making accounts locked by default, but it was still possible to make public posts via the API.