### PR TITLE
Shorten media urls for activitypub serialization

### DIFF
--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -26,6 +26,13 @@ class MediaProxyController < ApplicationController
     redirect_to full_asset_url(@media_attachment.file.url(version))
   end
 
+  def short
+    media_token = MediaToken.find(params[:id])
+    @media_attachment = media_token.media_attachment
+
+    redirect_to full_asset_url(@media_attachment.file.url(:original))
+  end
+
   private
 
   def redownload!

--- a/app/models/media_attachment.rb
+++ b/app/models/media_attachment.rb
@@ -176,6 +176,8 @@ class MediaAttachment < ApplicationRecord
   belongs_to :status,           inverse_of: :media_attachments, optional: true
   belongs_to :scheduled_status, inverse_of: :media_attachments, optional: true
 
+  has_many :media_tokens, dependent: :destroy
+
   has_attached_file :file,
                     styles: ->(f) { file_styles f },
                     processors: ->(f) { file_processors f },
@@ -268,6 +270,10 @@ class MediaAttachment < ApplicationRecord
 
   def delay_processing_for_attachment?(attachment_name)
     delay_processing? && attachment_name == :file
+  end
+
+  def generate_token
+    media_tokens.create
   end
 
   after_commit :enqueue_processing, on: :create

--- a/app/models/media_token.rb
+++ b/app/models/media_token.rb
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: media_tokens
+#
+#  id                  :bigint(8)        not null, primary key
+#  media_attachment_id :bigint(8)
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#
+class MediaToken < ApplicationRecord
+  belongs_to :media_attachment
+end

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -207,7 +207,12 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
     end
 
     def url
-      object.local? ? full_asset_url(object.file.url(:original, false)) : object.remote_url
+      if object.local?
+        token = object.generate_token
+        media_short_url(token.id)
+      else
+        object.remote_url
+      end
     end
 
     def focal_point?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -226,6 +226,7 @@ Rails.application.routes.draw do
   resource :statuses_cleanup, controller: :statuses_cleanup, only: [:show, :update]
 
   get '/media_proxy/:id/(*any)', to: 'media_proxy#show', as: :media_proxy, format: false
+  get '/media/short/:id', to: 'media_proxy#short', as: :media_short, format: false
   get '/backups/:id/download', to: 'backups#download', as: :download_backup, format: false
 
   resource :authorize_interaction, only: [:show, :create]

--- a/db/migrate/20240409213344_create_media_tokens.rb
+++ b/db/migrate/20240409213344_create_media_tokens.rb
@@ -1,0 +1,9 @@
+class CreateMediaTokens < ActiveRecord::Migration[6.1]
+  def change
+    create_table :media_tokens do |t|
+      t.bigint :media_attachment_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_31_214139) do
+ActiveRecord::Schema.define(version: 2024_04_09_213344) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -616,6 +616,12 @@ ActiveRecord::Schema.define(version: 2023_07_31_214139) do
     t.index ["scheduled_status_id"], name: "index_media_attachments_on_scheduled_status_id", where: "(scheduled_status_id IS NOT NULL)"
     t.index ["shortcode"], name: "index_media_attachments_on_shortcode", unique: true, opclass: :text_pattern_ops, where: "(shortcode IS NOT NULL)"
     t.index ["status_id"], name: "index_media_attachments_on_status_id"
+  end
+
+  create_table "media_tokens", force: :cascade do |t|
+    t.bigint "media_attachment_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "mentions", force: :cascade do |t|

--- a/spec/controllers/media_proxy_controller_spec.rb
+++ b/spec/controllers/media_proxy_controller_spec.rb
@@ -39,4 +39,15 @@ describe MediaProxyController do
       expect(response).to have_http_status(404)
     end
   end
+
+  describe '#short' do
+    it 'redirects to the original url' do
+      media_attachment = Fabricate(:media_attachment)
+      token = media_attachment.generate_token
+      get :short, params: { id: token.id }
+
+      expect(response).to have_http_status(302)
+      expect(response.headers['Location']).to match(media_attachment.file.url(:original))
+    end
+  end
 end

--- a/spec/serializers/activitypub/note_spec.rb
+++ b/spec/serializers/activitypub/note_spec.rb
@@ -5,11 +5,11 @@ require 'rails_helper'
 describe ActivityPub::NoteSerializer do
   let!(:account) { Fabricate(:account) }
   let!(:other)   { Fabricate(:account) }
-  let!(:parent)  { Fabricate(:status, account: account, visibility: :public) }
-  let!(:reply1)  { Fabricate(:status, account: account, thread: parent, visibility: :public) }
-  let!(:reply2)  { Fabricate(:status, account: account, thread: parent, visibility: :public) }
-  let!(:reply3)  { Fabricate(:status, account: other, thread: parent, visibility: :public) }
-  let!(:reply4)  { Fabricate(:status, account: account, thread: parent, visibility: :public) }
+  let!(:parent)  { Fabricate(:status, account: account, media_attachments: [Fabricate(:media_attachment)]) }
+  let!(:reply1)  { Fabricate(:status, account: account, thread: parent) }
+  let!(:reply2)  { Fabricate(:status, account: account, thread: parent) }
+  let!(:reply3)  { Fabricate(:status, account: other, thread: parent) }
+  let!(:reply4)  { Fabricate(:status, account: account, thread: parent) }
   let!(:reply5)  { Fabricate(:status, account: account, thread: parent, visibility: :direct) }
 
   before(:each) do
@@ -40,5 +40,10 @@ describe ActivityPub::NoteSerializer do
 
   it 'does not include replies with direct visibility in its replies collection' do
     expect(subject['replies']['first']['items']).to_not include(reply5.uri)
+  end
+
+  it 'returns media attachments with short urls' do
+    expect(subject['attachment']).to be_kind_of(Array)
+    expect(subject['attachment'].first['url']).to match(%r{media\/short\/\d+\/original})
   end
 end


### PR DESCRIPTION
Some other federated platforms, such as pixelfed, have very short media attachment url length limits. This means that the signed S3 urls get truncated and images in posts break.

This changes the ActivityPub serialization for notes to create short urls for attachments that proxy to the signed url. This obviously defeats some of the purpose of using signed urls, so I am generating a token per serialization so that tokens can be revoked in case of misuse/leaking by an unscrupulous recipient.