### PR TITLE
Automatic feeds (lists) for circles

### DIFF
--- a/app/models/circle.rb
+++ b/app/models/circle.rb
@@ -9,6 +9,7 @@
 #  title      :string           default(""), not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  list_id    :bigint(8)
 #
 class Circle < ApplicationRecord
   include Paginable
@@ -18,5 +19,15 @@ class Circle < ApplicationRecord
   has_many :circle_accounts, inverse_of: :circle, dependent: :destroy
   has_many :accounts, through: :circle_accounts
 
+  belongs_to :list, optional: true
+
   validates :title, presence: true
+
+  after_commit :create_corresponding_list, on: :create
+
+  private
+
+  def create_corresponding_list
+    create_list(title: title, account_id: account_id)
+  end
 end

--- a/app/models/circle.rb
+++ b/app/models/circle.rb
@@ -19,7 +19,7 @@ class Circle < ApplicationRecord
   has_many :circle_accounts, inverse_of: :circle, dependent: :destroy
   has_many :accounts, through: :circle_accounts
 
-  belongs_to :list, optional: true
+  belongs_to :list, optional: true, dependent: :destroy
 
   validates :title, presence: true
 

--- a/app/models/circle.rb
+++ b/app/models/circle.rb
@@ -23,7 +23,7 @@ class Circle < ApplicationRecord
 
   validates :title, presence: true
 
-  after_commit :create_corresponding_list, on: :create
+  before_create :create_corresponding_list
 
   private
 

--- a/app/models/circle_account.rb
+++ b/app/models/circle_account.rb
@@ -25,11 +25,13 @@ class CircleAccount < ApplicationRecord
   private
 
   def add_list_account
-    circle.list.list_accounts.create!(account_id: account_id)
+    circle.list.list_accounts.create(account_id: account_id)
+  rescue ActiveRecord::RecordNotFound
+    # Do nothing
   end
 
   def remove_list_account
-    circle.list.list_accounts.find_by(account_id: account_id).destroy!
+    circle.list.list_accounts.find_by(account_id: account_id)&.destroy
   end
 
   def set_follow

--- a/app/models/circle_account.rb
+++ b/app/models/circle_account.rb
@@ -19,8 +19,18 @@ class CircleAccount < ApplicationRecord
   validates :account_id, uniqueness: { scope: :circle_id }
 
   before_validation :set_follow
+  after_commit :add_list_account, on: :create
+  after_commit :remove_list_account, on: :destroy
 
   private
+
+  def add_list_account
+    circle.list.list_accounts.create!(account_id: account_id)
+  end
+
+  def remove_list_account
+    circle.list.list_accounts.find_by(account_id: account_id).destroy!
+  end
 
   def set_follow
     self.follow = Follow.find_by!(target_account_id: circle.account_id, account_id: account.id)

--- a/app/models/concerns/account_interactions.rb
+++ b/app/models/concerns/account_interactions.rb
@@ -313,7 +313,7 @@ module AccountInteractions
   private
 
   def create_default_circle
-    owned_circles.create(title: 'inner circle')
+    owned_circles.create(title: 'inner circle') if local?
   end
 
   def remove_potential_friendship(other_account)

--- a/app/models/list_account.rb
+++ b/app/models/list_account.rb
@@ -22,7 +22,13 @@ class ListAccount < ApplicationRecord
 
   before_validation :set_follow
 
+  after_create :backfill_list
+
   private
+
+  def backfill_list
+    FeedManager.instance.merge_into_list(account, list)
+  end
 
   def set_follow
     return if list.account_id == account.id

--- a/app/serializers/rest/circle_serializer.rb
+++ b/app/serializers/rest/circle_serializer.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class REST::CircleSerializer < ActiveModel::Serializer
-  attributes :id, :title
+  attributes :id, :title, :list
 
   def id
     object.id.to_s

--- a/db/migrate/20240617205154_add_list_to_circles.rb
+++ b/db/migrate/20240617205154_add_list_to_circles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddListToCircles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :circles, :list_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_09_213344) do
+ActiveRecord::Schema[7.0].define(version: 2024_06_17_205154) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -348,6 +348,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_09_213344) do
     t.string "title", default: "", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.bigint "list_id"
     t.index ["account_id"], name: "index_circles_on_account_id"
   end
 

--- a/spec/models/circle_account_spec.rb
+++ b/spec/models/circle_account_spec.rb
@@ -1,4 +1,25 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe CircleAccount, type: :model do
+RSpec.describe CircleAccount do
+  it 'creates a list account after creation' do
+    circle = Fabricate(:circle)
+    account = Fabricate(:account)
+    Fabricate(:follow, account: account, target_account: circle.account)
+    Fabricate(:follow, account: circle.account, target_account: account)
+    Fabricate(:circle_account, circle: circle, account: account)
+    expect(circle.list.accounts).to include(account)
+  end
+
+  it 'removes a list account after destruction' do
+    circle = Fabricate(:circle)
+    account = Fabricate(:account)
+    Fabricate(:follow, account: account, target_account: circle.account)
+    Fabricate(:follow, account: circle.account, target_account: account)
+    circle_account = Fabricate(:circle_account, circle: circle, account: account)
+
+    circle_account.destroy
+    expect(circle.list.accounts).to_not include(account)
+  end
 end

--- a/spec/models/circle_account_spec.rb
+++ b/spec/models/circle_account_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe CircleAccount do
     expect(circle.list.accounts).to include(account)
   end
 
+  it 'does not throw an error if list account is not able to be created due to lack of following' do
+    circle = Fabricate(:circle)
+    account = Fabricate(:account)
+    Fabricate(:follow, account: account, target_account: circle.account)
+    expect { Fabricate(:circle_account, circle: circle, account: account) }.to_not raise_error
+  end
+
   it 'removes a list account after destruction' do
     circle = Fabricate(:circle)
     account = Fabricate(:account)
@@ -21,5 +28,15 @@ RSpec.describe CircleAccount do
 
     circle_account.destroy
     expect(circle.list.accounts).to_not include(account)
+  end
+
+  it 'does not throw an error if the list account to be removed after destruction does not exist' do
+    circle = Fabricate(:circle)
+    account = Fabricate(:account)
+    Fabricate(:follow, account: account, target_account: circle.account)
+    circle_account = Fabricate(:circle_account, circle: circle, account: account)
+    expect(circle.list.accounts).to_not include(account)
+
+    circle_account.destroy
   end
 end

--- a/spec/models/circle_spec.rb
+++ b/spec/models/circle_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe Circle do
   it 'creates a corresponding list after creation' do
     circle = Fabricate(:circle)
-    expect(circle.list).to be_present
+    expect(circle.reload.list).to be_present
     expect(circle.list.title).to eq(circle.title)
     expect(circle.list.account).to eq(circle.account)
   end

--- a/spec/models/circle_spec.rb
+++ b/spec/models/circle_spec.rb
@@ -1,4 +1,12 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe Circle, type: :model do
+RSpec.describe Circle do
+  it 'creates a corresponding list after creation' do
+    circle = Fabricate(:circle)
+    expect(circle.list).to be_present
+    expect(circle.list.title).to eq(circle.title)
+    expect(circle.list.account).to eq(circle.account)
+  end
 end

--- a/spec/models/concerns/account_interactions_spec.rb
+++ b/spec/models/concerns/account_interactions_spec.rb
@@ -4,6 +4,7 @@ require 'rails_helper'
 
 describe AccountInteractions do
   let(:account)            { Fabricate(:account, username: 'account') }
+  let(:remote_account)     { Fabricate(:account, username: 'account', domain: 'example.com') }
   let(:account_id)         { account.id }
   let(:account_ids)        { [account_id] }
   let(:target_account)     { Fabricate(:account, username: 'target') }
@@ -725,9 +726,13 @@ describe AccountInteractions do
   end
 
   describe 'default circle' do
-    it 'creates an inner circle for new accounts' do
+    it 'creates an inner circle for new local accounts' do
       expect(account.owned_circles.count).to eq 1
       expect(account.owned_circles.first.title).to eq 'inner circle'
+    end
+
+    it 'does not create a circle for new remote accounts' do
+      expect(remote_account.owned_circles.count).to eq 0
     end
   end
 


### PR DESCRIPTION
This PR makes an associated list for each circle when it is created and automatically adds and removes accounts from the corresponding list when they are added or removed from the circle. This allows for a automatic dedicated feed for a circle.

I also changed list behavior to backfill the feed when a new account is added to the list so that users don't have to wait for the next post to start seeing items in the list's feed.

In testing this out, I also noticed that a default circle was incorrectly being made for remote accounts upon creation, so I fixed that.