### PR TITLE
Implement FEP-7888 - conversation context

### DIFF
--- a/app/controllers/activitypub/contexts_controller.rb
+++ b/app/controllers/activitypub/contexts_controller.rb
@@ -2,15 +2,59 @@
 
 class ActivityPub::ContextsController < ActivityPub::BaseController
   before_action :set_conversation
+  before_action :set_items, only: :items
+
+  DESCENDANTS_LIMIT = 60
 
   def show
     expires_in 3.minutes, public: public_fetch_mode?
     render_with_cache json: @conversation, serializer: ActivityPub::ContextSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'
   end
 
+  def items
+    expires_in 3.minutes, public: public_fetch_mode?
+    render_with_cache json: items_collection_presenter, serializer: ActivityPub::CollectionSerializer, adapter: ActivityPub::Adapter, content_type: 'application/activity+json'
+  end
+
   private
 
   def set_conversation
     @conversation = Conversation.local.find(params[:id])
+  end
+
+  def set_items
+    @items = @conversation.statuses.distributable_visibility.paginate_by_min_id(DESCENDANTS_LIMIT, params[:min_id])
+  end
+
+  def items_collection_presenter
+    page = ActivityPub::CollectionPresenter.new(
+      id: context_items_url(@conversation, page_params),
+      type: :unordered,
+      part_of: context_items_url(@conversation),
+      next: next_page,
+      items: @conversation.statuses.map { |status| status.local? ? status : status.uri }
+    )
+
+    return page if page_requested?
+
+    ActivityPub::CollectionPresenter.new(
+      id: context_items_url(@conversation),
+      type: :unordered,
+      first: page
+    )
+  end
+
+  def page_requested?
+    truthy_param?(:page)
+  end
+
+  def next_page
+    return nil if @conversation.statuses.size < DESCENDANTS_LIMIT
+
+    context_items_url(@conversation, page: true, min_id: @conversation.statuses.last.id)
+  end
+
+  def page_params
+    params.permit(:page, :min_id)
   end
 end

--- a/app/controllers/activitypub/contexts_controller.rb
+++ b/app/controllers/activitypub/contexts_controller.rb
@@ -18,6 +18,10 @@ class ActivityPub::ContextsController < ActivityPub::BaseController
 
   private
 
+  def account_required?
+    false
+  end
+
   def set_conversation
     @conversation = Conversation.local.find(params[:id])
   end

--- a/app/controllers/activitypub/contexts_controller.rb
+++ b/app/controllers/activitypub/contexts_controller.rb
@@ -36,7 +36,7 @@ class ActivityPub::ContextsController < ActivityPub::BaseController
       type: :unordered,
       part_of: context_items_url(@conversation),
       next: next_page,
-      items: @conversation.statuses.map { |status| status.local? ? status : status.uri }
+      items: @items.map { |status| status.local? ? status : status.uri }
     )
 
     return page if page_requested?
@@ -53,9 +53,9 @@ class ActivityPub::ContextsController < ActivityPub::BaseController
   end
 
   def next_page
-    return nil if @conversation.statuses.size < DESCENDANTS_LIMIT
+    return nil if @items.size < DESCENDANTS_LIMIT
 
-    context_items_url(@conversation, page: true, min_id: @conversation.statuses.last.id)
+    context_items_url(@conversation, page: true, min_id: @items.last.id)
   end
 
   def page_params

--- a/app/controllers/statuses_controller.rb
+++ b/app/controllers/statuses_controller.rb
@@ -59,7 +59,7 @@ class StatusesController < ApplicationController
   def set_status
     @status = @account.statuses.find(params[:id])
 
-    if request.authorization.present? && request.authorization.match(/^Bearer /i)
+    if !@status.distributable? && request.authorization.present? && request.authorization.match(/^Bearer /i)
       raise Mastodon::NotPermittedError unless @status.capability_tokens.find_by(token: request.authorization.gsub(/^Bearer /i, ''))
     else
       authorize @status, :show?

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -97,7 +97,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
       sensitive: @account.sensitized? || @status_parser.sensitive || false,
       visibility: @status_parser.visibility,
       thread: replied_to_status,
-      conversation: conversation_from_uri(@object['conversation']),
+      conversation: @options[:conversation] || conversation_from_uri(@object['conversation']),
       media_attachment_ids: attachment_ids,
       ordered_media_attachment_ids: attachment_ids,
       poll: process_poll,

--- a/app/lib/activitypub/activity/create.rb
+++ b/app/lib/activitypub/activity/create.rb
@@ -58,6 +58,7 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
     resolve_thread(@status)
     resolve_unresolved_mentions(@status)
     fetch_replies(@status)
+    fetch_conversation_statuses(@status)
     distribute
     forward_for_conversation
     forward_for_reply
@@ -455,5 +456,17 @@ class ActivityPub::Activity::Create < ActivityPub::Activity
   rescue ActiveRecord::StaleObjectError
     poll.reload
     retry
+  end
+
+  def fetch_conversation_statuses(status)
+    return if status.conversation.nil? || status.conversation.local?
+
+    collection = @object['context']
+    return if collection.blank?
+
+    uri = value_or_id(collection)
+    ActivityPub::FetchConversationStatusesWorker.perform_async(status.id, uri, { 'request_id' => @options[:request_id] }) unless uri.nil?
+  rescue => e
+    Rails.logger.warn "Error fetching conversation statuses: #{e}"
   end
 end

--- a/app/lib/activitypub/tag_manager.rb
+++ b/app/lib/activitypub/tag_manager.rb
@@ -39,6 +39,8 @@ class ActivityPub::TagManager
     case target.object_type
     when :person
       target.instance_actor? ? instance_actor_url : account_url(target)
+    when :conversation
+      context_url(target)
     when :note, :comment, :activity
       return activity_account_status_url(target.account, target) if target.reblog?
 
@@ -66,6 +68,12 @@ class ActivityPub::TagManager
     raise ArgumentError, 'target must be a local activity' unless %i(note comment activity).include?(target.object_type) && target.local?
 
     activity_account_status_url(target.account, target)
+  end
+
+  def context_uri_for(target, page_params = nil)
+    raise ArgumentError, 'target must be a local activity' unless %i(note comment activity).include?(target.object_type) && target.local?
+
+    context_items_url(target.conversation, page_params)
   end
 
   def replies_uri_for(target, page_params = nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -128,8 +128,6 @@ class User < ApplicationRecord
   scope :matches_ip, ->(value) { left_joins(:ips).where('user_ips.ip <<= ?', value).group('users.id') }
 
   before_validation :sanitize_role
-  before_validation :sanitize_time_zone
-  before_validation :sanitize_locale
   before_create :set_approved
   after_commit :send_pending_devise_notifications
   after_create_commit :trigger_webhooks

--- a/app/serializers/activitypub/context_serializer.rb
+++ b/app/serializers/activitypub/context_serializer.rb
@@ -3,12 +3,16 @@
 class ActivityPub::ContextSerializer < ActivityPub::Serializer
   include RoutingHelper
 
-  attributes :id, :type, :first
+  attributes :id, :type, :first, :attributed_to
 
   has_one :first, serializer: ActivityPub::CollectionSerializer
 
   def id
     ActivityPub::TagManager.instance.uri_for(object)
+  end
+
+  def attributed_to
+    ActivityPub::TagManager.instance.uri_for(object.parent_account)
   end
 
   def type

--- a/app/serializers/activitypub/context_serializer.rb
+++ b/app/serializers/activitypub/context_serializer.rb
@@ -3,7 +3,9 @@
 class ActivityPub::ContextSerializer < ActivityPub::Serializer
   include RoutingHelper
 
-  attributes :id, :type
+  attributes :id, :type, :first
+
+  has_one :first, serializer: ActivityPub::CollectionSerializer
 
   def id
     ActivityPub::TagManager.instance.uri_for(object)
@@ -11,5 +13,19 @@ class ActivityPub::ContextSerializer < ActivityPub::Serializer
 
   def type
     'Collection'
+  end
+
+  def first
+    conversation_statuses = object.statuses[0..5]
+    last_status = conversation_statuses.last
+    conversation_statuses = conversation_statuses.pluck(:id, :uri)
+    last_id = conversation_statuses.last&.first
+
+    ActivityPub::CollectionPresenter.new(
+      type: :unordered,
+      part_of: ActivityPub::TagManager.instance.uri_for(object),
+      items: conversation_statuses.map(&:second),
+      next: last_id ? ActivityPub::TagManager.instance.context_uri_for(last_status, page: true, min_id: last_id) : ActivityPub::TagManager.instance.context_uri_for(last_status, page: true, only_other_accounts: true)
+    )
   end
 end

--- a/app/serializers/activitypub/context_serializer.rb
+++ b/app/serializers/activitypub/context_serializer.rb
@@ -3,17 +3,13 @@
 class ActivityPub::ContextSerializer < ActivityPub::Serializer
   include RoutingHelper
 
-  attributes :id, :type, :inbox
+  attributes :id, :type
 
   def id
     ActivityPub::TagManager.instance.uri_for(object)
   end
 
   def type
-    'Group'
-  end
-
-  def inbox
-    account_inbox_url(object.parent_account)
+    'Collection'
   end
 end

--- a/app/serializers/activitypub/context_serializer.rb
+++ b/app/serializers/activitypub/context_serializer.rb
@@ -24,12 +24,17 @@ class ActivityPub::ContextSerializer < ActivityPub::Serializer
     last_status = conversation_statuses.last
     conversation_statuses = conversation_statuses.pluck(:id, :uri)
     last_id = conversation_statuses.last&.first
+    has_more = object.statuses.count > ActivityPub::ContextsController::DESCENDANTS_LIMIT
+
+    next_page = if has_more
+                  last_id ? ActivityPub::TagManager.instance.context_uri_for(last_status, page: true, min_id: last_id) : ActivityPub::TagManager.instance.context_uri_for(last_status, page: true, only_other_accounts: true)
+                end
 
     ActivityPub::CollectionPresenter.new(
       type: :unordered,
       part_of: ActivityPub::TagManager.instance.uri_for(object),
       items: conversation_statuses.map(&:second),
-      next: last_id ? ActivityPub::TagManager.instance.context_uri_for(last_status, page: true, min_id: last_id) : ActivityPub::TagManager.instance.context_uri_for(last_status, page: true, only_other_accounts: true)
+      next: next_page
     )
   end
 end

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -18,8 +18,8 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
   has_many :virtual_attachments, key: :attachment
   has_many :virtual_tags, key: :tag
 
+  has_one :context
   has_one :replies, serializer: ActivityPub::CollectionSerializer, if: :local?
-  has_one :context, serializer: ActivityPub::CollectionSerializer, if: :local?
   has_one :likes, serializer: ActivityPub::CollectionSerializer, if: :local?
   has_one :shares, serializer: ActivityPub::CollectionSerializer, if: :local?
 
@@ -161,19 +161,7 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
     return if object.conversation.nil?
     return if object.conversation.parent_status.nil?
 
-    conversation_statuses = object.conversation.statuses[0..5].pluck(:id, :uri)
-    last_id = conversation_statuses.last&.first
-
-    ActivityPub::CollectionPresenter.new(
-      type: :unordered,
-      id: ActivityPub::TagManager.instance.uri_for(object.conversation),
-      first: ActivityPub::CollectionPresenter.new(
-        type: :unordered,
-        part_of: ActivityPub::TagManager.instance.uri_for(object.conversation),
-        items: conversation_statuses.map(&:second),
-        next: last_id ? ActivityPub::TagManager.instance.context_uri_for(object, page: true, min_id: last_id) : ActivityPub::TagManager.instance.context_uri_for(object, page: true, only_other_accounts: true)
-      )
-    )
+    ActivityPub::TagManager.instance.uri_for(object.conversation)
   end
 
   def local?

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -158,8 +158,9 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
 
   def context
     return if object.conversation.nil?
+    return if object.conversation.parent_status.nil?
 
-    ActivityPub::TagManager.instance.uri_for(object.conversation)
+    ActivityPub::TagManager.instance.uri_for(object.conversation.parent_status)
   end
 
   def local?

--- a/app/serializers/activitypub/note_serializer.rb
+++ b/app/serializers/activitypub/note_serializer.rb
@@ -19,6 +19,7 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
   has_many :virtual_tags, key: :tag
 
   has_one :replies, serializer: ActivityPub::CollectionSerializer, if: :local?
+  has_one :context, serializer: ActivityPub::CollectionSerializer, if: :local?
   has_one :likes, serializer: ActivityPub::CollectionSerializer, if: :local?
   has_one :shares, serializer: ActivityPub::CollectionSerializer, if: :local?
 
@@ -160,7 +161,19 @@ class ActivityPub::NoteSerializer < ActivityPub::Serializer
     return if object.conversation.nil?
     return if object.conversation.parent_status.nil?
 
-    ActivityPub::TagManager.instance.uri_for(object.conversation.parent_status)
+    conversation_statuses = object.conversation.statuses[0..5].pluck(:id, :uri)
+    last_id = conversation_statuses.last&.first
+
+    ActivityPub::CollectionPresenter.new(
+      type: :unordered,
+      id: ActivityPub::TagManager.instance.uri_for(object.conversation),
+      first: ActivityPub::CollectionPresenter.new(
+        type: :unordered,
+        part_of: ActivityPub::TagManager.instance.uri_for(object.conversation),
+        items: conversation_statuses.map(&:second),
+        next: last_id ? ActivityPub::TagManager.instance.context_uri_for(object, page: true, min_id: last_id) : ActivityPub::TagManager.instance.context_uri_for(object, page: true, only_other_accounts: true)
+      )
+    )
   end
 
   def local?

--- a/app/services/activitypub/fetch_conversation_statuses_service.rb
+++ b/app/services/activitypub/fetch_conversation_statuses_service.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+class ActivityPub::FetchConversationStatusesService < BaseService
+  include JsonLdHelper
+
+  def call(parent_status, collection_or_uri, allow_synchronous_requests: true, request_id: nil)
+    @parent_status = parent_status
+    @account = @parent_status.account
+    @allow_synchronous_requests = allow_synchronous_requests
+    @request_id = request_id
+
+    process_collection(collection_or_uri)
+  end
+
+  private
+
+  def process_collection(collection_or_uri)
+    collection = fetch_collection(collection_or_uri)
+    return unless collection.is_a?(Hash)
+
+    if collection['first'].present?
+      process_collection(collection['first'])
+
+      ActivityPub::FetchConversationStatusesWorker.perform_in(rand(30..60).seconds, @parent_status.id, collection['next'], { 'request_id' => @request_id }) if collection['next'].present?
+    else
+      items = case collection['type']
+              when 'Collection', 'CollectionPage'
+                as_array(collection['items'])
+              when 'OrderedCollection', 'OrderedCollectionPage'
+                as_array(collection['orderedItems'])
+              end
+
+      return if items.nil?
+
+      items.each_slice(10) do |chunk|
+        ActivityPub::FetchConversationStatusesWorker.push_bulk(chunk) do |item|
+          [@parent_status.id, value_or_id(item), { request_id: @request_id }]
+        end
+      end
+    end
+  end
+
+  def fetch_collection(collection_or_uri)
+    return collection_or_uri if collection_or_uri.is_a?(Hash)
+    return unless @allow_synchronous_requests
+
+    # NOTE: For backward compatibility reasons, Mastodon signs outgoing
+    # queries incorrectly by default.
+    #
+    # Therefore, retry with correct signatures if this fails.
+    begin
+      fetch_resource_without_id_validation(collection_or_uri, nil, true)
+    rescue Mastodon::UnexpectedResponseError => e
+      raise unless e.response && e.response.code == 401 && Addressable::URI.parse(collection_or_uri).query.present?
+
+      fetch_resource_without_id_validation(collection_or_uri, nil, true, request_options: { omit_query_string: false })
+    end
+  end
+end

--- a/app/services/activitypub/fetch_remote_status_service.rb
+++ b/app/services/activitypub/fetch_remote_status_service.rb
@@ -8,7 +8,7 @@ class ActivityPub::FetchRemoteStatusService < BaseService
   DISCOVERIES_PER_REQUEST = 1000
 
   # Should be called when uri has already been checked for locality
-  def call(uri, prefetched_body: nil, on_behalf_of: nil, expected_actor_uri: nil, request_id: nil)
+  def call(uri, prefetched_body: nil, on_behalf_of: nil, expected_actor_uri: nil, request_id: nil, conversation: nil)
     return if domain_not_allowed?(uri)
 
     @request_id = request_id || "#{Time.now.utc.to_i}-status-#{uri}"
@@ -52,7 +52,7 @@ class ActivityPub::FetchRemoteStatusService < BaseService
       return nil if discoveries > DISCOVERIES_PER_REQUEST
     end
 
-    ActivityPub::Activity.factory(activity_json, actor, request_id: @request_id).perform
+    ActivityPub::Activity.factory(activity_json, actor, request_id: @request_id, conversation: conversation).perform
   end
 
   private

--- a/app/workers/activitypub/fetch_conversation_statuses_worker.rb
+++ b/app/workers/activitypub/fetch_conversation_statuses_worker.rb
@@ -14,12 +14,12 @@ class ActivityPub::FetchConversationStatusesWorker
       if resource.is_a?(Hash) && %w(Collection CollectionPage OrderedCollection OrderedCollectionPage).include?(resource['type'])
         ActivityPub::FetchConversationStatusesService.new.call(parent_status, uri, **options.deep_symbolize_keys)
       else
-        ActivityPub::FetchRemoteStatusService.new.call(uri, **options.deep_symbolize_keys)
+        ActivityPub::FetchRemoteStatusService.new.call(uri, conversation: parent_status.conversation, **options.deep_symbolize_keys)
       end
     rescue Mastodon::UnexpectedResponseError, HTTP::Error, OpenSSL::SSL::SSLError => e
       Rails.logger.warn "Error fetching resource #{uri}: #{e}"
       # If we can't fetch the resource, assume it's a status to maintain backward compatibility
-      ActivityPub::FetchRemoteStatusService.new.call(uri, **options.deep_symbolize_keys)
+      ActivityPub::FetchRemoteStatusService.new.call(uri, conversation: parent_status.conversation, **options.deep_symbolize_keys)
     end
   end
 end

--- a/app/workers/activitypub/fetch_conversation_statuses_worker.rb
+++ b/app/workers/activitypub/fetch_conversation_statuses_worker.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class ActivityPub::FetchConversationStatusesWorker
+  include Sidekiq::Worker
+  include JsonLdHelper
+
+  sidekiq_options queue: 'pull', retry: 2
+
+  def perform(parent_status_id, uri, options = {})
+    parent_status = Status.find(parent_status_id)
+
+    begin
+      resource = fetch_resource_without_id_validation(uri, nil, true)
+      if resource.is_a?(Hash) && %w(Collection CollectionPage OrderedCollection OrderedCollectionPage).include?(resource['type'])
+        ActivityPub::FetchConversationStatusesService.new.call(parent_status, uri, **options.deep_symbolize_keys)
+      else
+        ActivityPub::FetchRemoteStatusService.new.call(uri, **options.deep_symbolize_keys)
+      end
+    rescue Mastodon::UnexpectedResponseError, HTTP::Error, OpenSSL::SSL::SSLError => e
+      Rails.logger.warn "Error fetching resource #{uri}: #{e}"
+      # If we can't fetch the resource, assume it's a status to maintain backward compatibility
+      ActivityPub::FetchRemoteStatusService.new.call(uri, **options.deep_symbolize_keys)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -143,7 +143,9 @@ Rails.application.routes.draw do
   end
 
   resource :inbox, only: [:create], module: :activitypub
-  resources :contexts, only: [:show], module: :activitypub
+  resources :contexts, only: [:show], module: :activitypub do
+    resources :items, only: [:index], module: :activitypub
+  end
 
   constraints(encoded_path: /%40.*/) do
     get '/:encoded_path', to: redirect { |params|

--- a/spec/controllers/activitypub/contexts_controller_spec.rb
+++ b/spec/controllers/activitypub/contexts_controller_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ActivityPub::ContextsController do
+  let(:user) { Fabricate(:user) }
+  let(:conversation) { Fabricate(:conversation) }
+
+  before do
+    allow(controller).to receive(:signed_request_actor).and_return(nil)
+  end
+
+  describe 'GET #show' do
+    context 'with few statuses' do
+      before do
+        3.times do
+          Fabricate(:status, visibility: :private, account: user.account, conversation: conversation)
+        end
+      end
+
+      it 'does not include a next page link' do
+        get :show, params: { id: conversation.id }
+        json = JSON.parse(response.body)
+        expect(json['first']['next']).to be_nil
+      end
+    end
+
+    context 'with many statuses' do
+      before do
+        (ActivityPub::ContextsController::DESCENDANTS_LIMIT + 1).times do
+          Fabricate(:status, visibility: :private, account: user.account, conversation: conversation)
+        end
+      end
+
+      it 'includes a next page link' do
+        get :show, params: { id: conversation.id }
+        json = JSON.parse(response.body)
+        expect(json['first']['next']).to_not be_nil
+      end
+    end
+  end
+end

--- a/spec/fabricators/conversation_fabricator.rb
+++ b/spec/fabricators/conversation_fabricator.rb
@@ -1,3 +1,5 @@
 # frozen_string_literal: true
 
-Fabricator(:conversation)
+Fabricator(:conversation) do
+  parent_account { Fabricate(:account) }
+end

--- a/spec/serializers/activitypub/note_serializer_spec.rb
+++ b/spec/serializers/activitypub/note_serializer_spec.rb
@@ -7,11 +7,11 @@ RSpec.describe ActivityPub::NoteSerializer do
 
   let!(:account) { Fabricate(:account) }
   let!(:other) { Fabricate(:account) }
-  let!(:parent) { Fabricate(:status, account: account, visibility: :public, language: 'zh-TW') }
-  let!(:reply_by_account_first) { Fabricate(:status, account: account, thread: parent, visibility: :public) }
-  let!(:reply_by_account_next) { Fabricate(:status, account: account, thread: parent, visibility: :public) }
-  let!(:reply_by_other_first) { Fabricate(:status, account: other, thread: parent, visibility: :public) }
-  let!(:reply_by_account_third) { Fabricate(:status, account: account, thread: parent, visibility: :public) }
+  let!(:parent) { Fabricate(:status, account: account, visibility: :private, language: 'zh-TW') }
+  let!(:reply_by_account_first) { Fabricate(:status, account: account, thread: parent, visibility: :private) }
+  let!(:reply_by_account_next) { Fabricate(:status, account: account, thread: parent, visibility: :private) }
+  let!(:reply_by_other_first) { Fabricate(:status, account: other, thread: parent, visibility: :private) }
+  let!(:reply_by_account_third) { Fabricate(:status, account: account, thread: parent, visibility: :private) }
   let!(:reply_by_account_visibility_direct) { Fabricate(:status, account: account, thread: parent, visibility: :direct) }
 
   it 'has the expected shape and replies collection' do
@@ -22,16 +22,24 @@ RSpec.describe ActivityPub::NoteSerializer do
       'contentMap' => include({
         'zh-TW' => a_kind_of(String),
       }),
+      'context' => include(
+        'type' => 'Collection',
+        'first' => include(
+          'type' => 'CollectionPage',
+          'items' => include(parent.uri, reply_by_account_first.uri, reply_by_account_next.uri,
+                             reply_by_account_third.uri, reply_by_other_first.uri)
+        )
+      ),
       'replies' => replies_collection_values,
     })
   end
 
   def replies_collection_values
     include(
-      'type' => eql('Collection'),
+      'type' => 'Collection',
       'first' => include(
-        'type' => eql('CollectionPage'),
-        'items' => reply_items
+        'type' => 'CollectionPage',
+        'items' => []
       )
     )
   end

--- a/spec/serializers/activitypub/note_serializer_spec.rb
+++ b/spec/serializers/activitypub/note_serializer_spec.rb
@@ -22,14 +22,7 @@ RSpec.describe ActivityPub::NoteSerializer do
       'contentMap' => include({
         'zh-TW' => a_kind_of(String),
       }),
-      'context' => include(
-        'type' => 'Collection',
-        'first' => include(
-          'type' => 'CollectionPage',
-          'items' => include(parent.uri, reply_by_account_first.uri, reply_by_account_next.uri,
-                             reply_by_account_third.uri, reply_by_other_first.uri)
-        )
-      ),
+      'context' => ActivityPub::TagManager.instance.uri_for(parent.conversation),
       'replies' => replies_collection_values,
     })
   end


### PR DESCRIPTION
This PR implements [FEP-7888](https://codeberg.org/fediverse/fep/src/branch/main/fep/7888/fep-7888.md) by:

- generating a `context` property and including it in the ActivityPub json-ld for all `Status`es
- consuming  the `context` property on incoming objects and fetching all objects listed in the `context` collection to backfill the conversation
- correctly assigning all posts fetched via the `context` collection to the same conversation, even if they don't contain the `context` property in their json-ld