### PR TITLE
Fix comment notifications

### DIFF
--- a/app/workers/feed_insert_worker.rb
+++ b/app/workers/feed_insert_worker.rb
@@ -52,8 +52,9 @@ class FeedInsertWorker
   end
 
   def notify?(filter_result)
-    return false if @type != :home || @status.reblog? || (@status.reply? && @status.in_reply_to_account_id != @status.account_id) ||
+    return false if @type != :home || @status.reblog? || (@status.reply? && @status.in_reply_to_account_id == @status.account_id) ||
                     filter_result == :filter
+    return true if @status.reply? && @status.in_reply_to_account_id == @follower.id # decodon non-mention comment notifications
 
     Follow.find_by(account: @follower, target_account: @status.account)&.notify?
   end

--- a/spec/workers/feed_insert_worker_spec.rb
+++ b/spec/workers/feed_insert_worker_spec.rb
@@ -10,6 +10,16 @@ RSpec.describe FeedInsertWorker do
     let(:status) { Fabricate(:status) }
     let(:list) { Fabricate(:list) }
 
+    context 'with decodon non-mention reply notifications' do
+      it 'notifies when the status is a reply to the follower' do
+        allow(LocalNotificationWorker).to receive(:perform_async)
+        reply = Fabricate(:status, in_reply_to_id: status.id, in_reply_to_account: status.account)
+        subject.perform(reply.id, status.account.id)
+
+        expect(LocalNotificationWorker).to have_received(:perform_async).with(status.account.id, reply.id, 'Status', 'status')
+      end
+    end
+
     context 'when there are no records' do
       it 'skips push with missing status' do
         instance = instance_double(FeedManager, push_to_home: nil)


### PR DESCRIPTION
I seem to have lost non-mention reply notifications after the recent merges with upstream; this puts them back.