### PR TITLE
Develop fork merge and CI strategy

### DIFF
--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - 'main'
       - 'stable-*'
+      - 'freq-main'  # Add your main development branch
   pull_request:
 
 env:

--- a/FORK_MANAGEMENT.md
+++ b/FORK_MANAGEMENT.md
@@ -1,0 +1,224 @@
+# Fork Management Strategy
+
+This document outlines the strategy for maintaining this Mastodon fork while minimizing merge conflicts and ensuring CI compatibility.
+
+## Overview
+
+This fork implements several customizations to Mastodon, particularly around status visibility restrictions. To maintain compatibility with upstream updates while preserving our changes, we use a **Configuration-Driven Approach**.
+
+## Key Changes Made
+
+### 1. Status Visibility Restrictions
+
+Instead of hard-coding role checks in the Status model, we now use:
+
+- **Configuration-based restrictions** via `config/settings.yml`
+- **Environment-specific behavior** (test mode allows upstream compatibility)
+- **Policy class** (`StatusVisibilityPolicy`) to centralize logic
+
+#### Files Modified:
+- `config/settings.yml` - Added fork-specific settings
+- `app/lib/status_visibility_policy.rb` - New policy class (CREATED)
+- `app/models/concerns/status/visibility.rb` - Replaced hard-coded validation
+- `spec/support/status_visibility_helpers.rb` - Test helpers (CREATED)
+- `spec/lib/status_visibility_policy_spec.rb` - Policy tests (CREATED)
+
+### 2. Test Environment Compatibility
+
+Tests now run in "upstream-compatible" mode by default:
+- `restrict_public_statuses: false` in test environment
+- Helper methods for tests that need to verify restriction behavior
+- CI can run all upstream tests without modification
+
+## Branch Strategy
+
+### Recommended Git Workflow
+
+```bash
+# 1. Set up upstream remote
+git remote add upstream https://github.com/mastodon/mastodon.git
+
+# 2. Create a clean upstream tracking branch
+git checkout -b upstream-main
+git fetch upstream main
+git reset --hard upstream/main
+git push origin upstream-main
+
+# 3. Keep your main branch for development
+git checkout freq-main  # Your main development branch
+
+# 4. For updates, merge upstream changes
+git fetch upstream main
+git checkout upstream-main
+git reset --hard upstream/main
+git push origin upstream-main
+
+git checkout freq-main
+git merge upstream-main  # This should have fewer conflicts now
+```
+
+### When Merge Conflicts Occur
+
+1. **Identify the conflict type:**
+   - Configuration conflicts → Update your config values
+   - Logic conflicts → Ensure your changes use the new policy approach
+   - Test conflicts → Use the visibility helpers
+
+2. **For recurring conflicts:**
+   - Consider moving more logic to configuration
+   - Use conditional logic instead of replacing upstream code
+   - Create wrapper methods instead of modifying existing ones
+
+## Development Workflow
+
+### Adding New Restrictions
+
+Instead of modifying core models directly:
+
+```ruby
+# ❌ DON'T: Modify upstream code directly
+validates :some_field, inclusion: { in: restricted_values }, if: -> { some_condition }
+
+# ✅ DO: Use policy classes and configuration
+validate :validate_some_field_restrictions
+
+private
+
+def validate_some_field_restrictions
+  return unless SomePolicy.restrictions_enabled?
+  # Your validation logic here
+end
+```
+
+### Testing Changes
+
+```ruby
+# Use helpers for upstream-compatible tests
+RSpec.describe 'some feature' do
+  it 'works with public statuses' do
+    status = create_public_status  # Uses proper permissions automatically
+    # Test logic here
+  end
+  
+  it 'respects visibility restrictions' do
+    with_visibility_restrictions do
+      # Test your custom behavior here
+    end
+  end
+end
+```
+
+### Configuration Management
+
+Fork-specific settings go in `config/settings.yml`:
+
+```yaml
+defaults: &defaults
+  # Existing upstream settings...
+  
+  # Fork-specific settings (group together)
+  restrict_public_statuses: true
+  some_other_restriction: true
+  allowed_roles: ['Owner', 'Admin']
+
+test:
+  <<: *defaults
+  # Override for test compatibility
+  restrict_public_statuses: false
+  some_other_restriction: false
+```
+
+## CI/CD Setup
+
+### Environment Variables
+
+Set these in your CI environment:
+
+```bash
+# Ensure test mode runs upstream-compatible
+RAILS_ENV=test
+DB_NAME=mastodon_test
+# ... other standard Mastodon test vars
+```
+
+### Test Commands
+
+```bash
+# Run all tests (should pass with upstream compatibility)
+bundle exec rspec
+
+# Run only fork-specific tests
+bundle exec rspec spec/lib/status_visibility_policy_spec.rb
+bundle exec rspec --tag fork_specific  # If you tag your custom tests
+```
+
+## Deployment
+
+### Production Environment
+
+Your production settings should enable restrictions:
+
+```yaml
+production:
+  <<: *defaults
+  restrict_public_statuses: true
+  # Other production-specific overrides
+```
+
+### Environment Variables
+
+If you need runtime configuration:
+
+```ruby
+# In your policy classes, you can also check ENV vars:
+def self.restrictions_enabled?
+  return ENV['DISABLE_RESTRICTIONS'] != 'true' if Rails.env.production?
+  Setting.restrict_public_statuses
+end
+```
+
+## Troubleshooting
+
+### Tests Failing After Upstream Merge
+
+1. **Check if new tests assume public statuses work:**
+   ```ruby
+   # Update test to use helper
+   let(:status) { create_public_status }  # Instead of Fabricate(:status, visibility: :public)
+   ```
+
+2. **Check if new validations conflict with your restrictions:**
+   - Look for new validations in Status model
+   - Ensure your policy class handles new cases
+
+3. **Check if settings.yml structure changed:**
+   - Merge any new default settings
+   - Ensure your custom settings are preserved
+
+### Merge Conflicts in Key Files
+
+- `app/models/concerns/status/visibility.rb`: Your changes should be minimal now
+- `config/settings.yml`: Add new upstream settings, preserve your custom ones
+- Test files: Use your helper methods instead of direct Fabricate calls
+
+## Future Considerations
+
+### When Upstream Changes Core Logic
+
+If upstream modifies status visibility logic significantly:
+
+1. Update your `StatusVisibilityPolicy` class to handle new cases
+2. Add new configuration options as needed
+3. Update tests to cover new scenarios
+4. Consider if your restrictions still make sense
+
+### Adding More Restrictions
+
+Follow the same pattern:
+1. Add configuration settings
+2. Create/update policy classes  
+3. Add validation methods that call the policy
+4. Create test helpers
+5. Add environment-specific overrides for test compatibility
+
+This approach keeps your changes maintainable and reduces merge conflicts over time.

--- a/app/lib/status_visibility_policy.rb
+++ b/app/lib/status_visibility_policy.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class StatusVisibilityPolicy
+  # Check if a user account can create statuses with the given visibility level
+  def self.can_create_visibility?(account, visibility)
+    return true unless restrictions_enabled?
+    return true if visibility.in?(%w[private direct limited]) # Always allow private visibilities
+    
+    # For public/unlisted visibility, check if user has required role
+    return true if account.nil? || account.user.nil? # Allow for system/remote accounts
+    
+    allowed_roles = Setting.public_status_allowed_roles || ['Owner']
+    user_role_name = account.user.role&.name
+    
+    allowed_roles.include?(user_role_name)
+  end
+  
+  # Check if the visibility restriction feature is enabled
+  def self.restrictions_enabled?
+    # In test environment, respect the configuration setting
+    # In other environments, default to enabled if not explicitly set
+    if Rails.env.test?
+      Setting.restrict_public_statuses
+    else
+      Setting.restrict_public_statuses != false
+    end
+  end
+  
+  # Get list of allowed visibilities for an account
+  def self.allowed_visibilities_for(account)
+    base_visibilities = %w[private direct limited]
+    
+    if can_create_visibility?(account, 'public')
+      base_visibilities + %w[public unlisted]
+    else
+      base_visibilities
+    end
+  end
+  
+  # Validation method that can be used in models
+  def self.validate_visibility_for_account(record)
+    return if record.account.nil?
+    return if can_create_visibility?(record.account, record.visibility)
+    
+    allowed_roles = Setting.public_status_allowed_roles || ['Owner']
+    role_names = allowed_roles.join(', ')
+    
+    record.errors.add(
+      :visibility, 
+      "Public and unlisted visibilities are restricted to accounts with roles: #{role_names}"
+    )
+  end
+end

--- a/app/models/concerns/status/visibility.rb
+++ b/app/models/concerns/status/visibility.rb
@@ -14,7 +14,7 @@ module Status::Visibility
     scope :not_direct_visibility, -> { where.not(visibility: :direct) }
 
     validates :visibility, exclusion: { in: %w(direct limited) }, if: :reblog?
-    validates :visibility, inclusion: { in: %w(private mutual direct limited) }, if: -> { account.local? && account.user.role != UserRole.find_by(name: 'Owner') }
+    validate :validate_visibility_restrictions
 
     before_validation :set_visibility, unless: :visibility?
   end
@@ -22,6 +22,10 @@ module Status::Visibility
   class_methods do
     def selectable_visibilities
       visibilities.keys - %w(direct limited)
+    end
+    
+    def selectable_visibilities_for(account)
+      StatusVisibilityPolicy.allowed_visibilities_for(account)
     end
   end
 
@@ -45,6 +49,18 @@ module Status::Visibility
   end
 
   def visibility_from_account
-    account.locked? ? :private : :public
+    if account.locked?
+      :private
+    elsif StatusVisibilityPolicy.can_create_visibility?(account, 'public')
+      :public
+    else
+      :private  # Default to private if public visibility is restricted
+    end
+  end
+  
+  def validate_visibility_restrictions
+    return unless account&.local?
+    
+    StatusVisibilityPolicy.validate_visibility_for_account(self)
   end
 end

--- a/bin/ci-test
+++ b/bin/ci-test
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# CI-friendly test runner that ensures upstream compatibility
+set -e
+
+echo "🔧 Setting up test environment for upstream compatibility..."
+
+# Ensure we're in test mode with restrictions disabled
+export RAILS_ENV=test
+export RESTRICT_PUBLIC_STATUSES=false  # Override in case setting is cached
+
+echo "🧪 Running RSpec tests..."
+if command -v flatware &> /dev/null; then
+    echo "Using flatware for parallel testing..."
+    bin/flatware rspec -r ./spec/flatware_helper.rb "$@"
+else
+    echo "Using standard RSpec..."
+    bin/rspec "$@"
+fi
+
+echo "✅ All tests completed!"

--- a/bin/setup-upstream
+++ b/bin/setup-upstream
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Setup script for upstream tracking
+set -e
+
+echo "Setting up upstream remote and tracking branch..."
+
+# Add upstream remote if it doesn't exist
+if ! git remote | grep -q "^upstream$"; then
+    echo "Adding upstream remote..."
+    git remote add upstream https://github.com/mastodon/mastodon.git
+else
+    echo "Upstream remote already exists"
+fi
+
+# Fetch upstream
+echo "Fetching from upstream..."
+git fetch upstream main
+
+# Create or update upstream tracking branch
+if git branch | grep -q "upstream-main"; then
+    echo "Updating existing upstream-main branch..."
+    git checkout upstream-main
+    git reset --hard upstream/main
+else
+    echo "Creating upstream-main tracking branch..."
+    git checkout -b upstream-main upstream/main
+fi
+
+# Push the upstream tracking branch to your fork
+echo "Pushing upstream-main to origin..."
+git push origin upstream-main -f
+
+# Return to your main development branch
+echo "Switching back to freq-main..."
+git checkout freq-main
+
+echo ""
+echo "✅ Setup complete!"
+echo ""
+echo "To update from upstream in the future:"
+echo "  1. ./bin/setup-upstream (updates tracking branch)"
+echo "  2. git merge upstream-main"
+echo ""
+echo "Current remotes:"
+git remote -v

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -56,12 +56,17 @@ defaults: &defaults
   backups_retention_period: 7
   captcha_enabled: false
   allow_referer_origin: false
+  # Fork-specific settings
+  restrict_public_statuses: true
+  public_status_allowed_roles: ['Owner'] # Roles that can post public/unlisted content
 
 development:
   <<: *defaults
 
 test:
   <<: *defaults
+  # In test mode, allow upstream compatibility by disabling restrictions
+  restrict_public_statuses: false
 
 production:
   <<: *defaults

--- a/spec/lib/status_visibility_policy_spec.rb
+++ b/spec/lib/status_visibility_policy_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe StatusVisibilityPolicy do
+  describe '.restrictions_enabled?' do
+    context 'in test environment' do
+      it 'returns false when setting is false' do
+        Setting.restrict_public_statuses = false
+        expect(described_class.restrictions_enabled?).to be false
+      end
+      
+      it 'returns true when setting is true' do
+        Setting.restrict_public_statuses = true
+        expect(described_class.restrictions_enabled?).to be true
+      end
+    end
+  end
+  
+  describe '.can_create_visibility?' do
+    let(:owner_user) { Fabricate(:owner_user) }
+    let(:regular_user) { Fabricate(:user) }
+    
+    context 'when restrictions are disabled' do
+      before { Setting.restrict_public_statuses = false }
+      
+      it 'allows any account to create public statuses' do
+        expect(described_class.can_create_visibility?(regular_user.account, 'public')).to be true
+      end
+      
+      it 'allows any account to create unlisted statuses' do  
+        expect(described_class.can_create_visibility?(regular_user.account, 'unlisted')).to be true
+      end
+    end
+    
+    context 'when restrictions are enabled' do
+      before { Setting.restrict_public_statuses = true }
+      
+      it 'allows Owner role to create public statuses' do
+        expect(described_class.can_create_visibility?(owner_user.account, 'public')).to be true
+      end
+      
+      it 'denies regular users to create public statuses' do
+        expect(described_class.can_create_visibility?(regular_user.account, 'public')).to be false
+      end
+      
+      it 'allows all accounts to create private statuses' do
+        expect(described_class.can_create_visibility?(regular_user.account, 'private')).to be true
+        expect(described_class.can_create_visibility?(owner_user.account, 'private')).to be true
+      end
+      
+      it 'allows all accounts to create direct statuses' do
+        expect(described_class.can_create_visibility?(regular_user.account, 'direct')).to be true
+      end
+    end
+  end
+  
+  describe '.allowed_visibilities_for' do
+    let(:owner_user) { Fabricate(:owner_user) }
+    let(:regular_user) { Fabricate(:user) }
+    
+    context 'when restrictions are disabled' do
+      before { Setting.restrict_public_statuses = false }
+      
+      it 'returns all visibilities for any user' do
+        expected = %w[private direct limited public unlisted]
+        expect(described_class.allowed_visibilities_for(regular_user.account)).to match_array(expected)
+      end
+    end
+    
+    context 'when restrictions are enabled' do
+      before { Setting.restrict_public_statuses = true }
+      
+      it 'returns all visibilities for owner' do
+        expected = %w[private direct limited public unlisted]
+        expect(described_class.allowed_visibilities_for(owner_user.account)).to match_array(expected)
+      end
+      
+      it 'returns limited visibilities for regular user' do
+        expected = %w[private direct limited]
+        expect(described_class.allowed_visibilities_for(regular_user.account)).to match_array(expected)
+      end
+    end
+  end
+  
+  describe '.validate_visibility_for_account' do
+    let(:owner_user) { Fabricate(:owner_user) }
+    let(:regular_user) { Fabricate(:user) }
+    
+    context 'when restrictions are enabled' do
+      before { Setting.restrict_public_statuses = true }
+      
+      it 'adds error for regular user trying to create public status' do
+        status = Status.new(account: regular_user.account, visibility: 'public')
+        described_class.validate_visibility_for_account(status)
+        
+        expect(status.errors[:visibility]).to be_present
+        expect(status.errors[:visibility].first).to include('Owner')
+      end
+      
+      it 'does not add error for owner creating public status' do
+        status = Status.new(account: owner_user.account, visibility: 'public')
+        described_class.validate_visibility_for_account(status)
+        
+        expect(status.errors[:visibility]).to be_empty
+      end
+      
+      it 'does not add error for private status' do
+        status = Status.new(account: regular_user.account, visibility: 'private')
+        described_class.validate_visibility_for_account(status)
+        
+        expect(status.errors[:visibility]).to be_empty
+      end
+    end
+  end
+end

--- a/spec/support/status_visibility_helpers.rb
+++ b/spec/support/status_visibility_helpers.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module StatusVisibilityHelpers
+  # Creates a status that would be allowed under the current visibility policy
+  def create_status_with_visibility(visibility, account: nil, **options)
+    account ||= case visibility.to_s
+                when 'public', 'unlisted'
+                  # In test mode, restrictions are disabled, so any account works
+                  # In production mode, this would need an Owner account
+                  if StatusVisibilityPolicy.restrictions_enabled?
+                    Fabricate(:owner_user).account
+                  else
+                    Fabricate(:account)
+                  end
+                else
+                  Fabricate(:account)
+                end
+    
+    Fabricate(:status, account: account, visibility: visibility, **options)
+  end
+  
+  # Creates a public status (with proper permissions)
+  def create_public_status(**options)
+    create_status_with_visibility(:public, **options)
+  end
+  
+  # Creates an unlisted status (with proper permissions) 
+  def create_unlisted_status(**options)
+    create_status_with_visibility(:unlisted, **options)
+  end
+  
+  # Temporarily disable visibility restrictions for a block
+  def without_visibility_restrictions(&block)
+    return yield unless StatusVisibilityPolicy.restrictions_enabled?
+    
+    original_setting = Setting.restrict_public_statuses
+    Setting.restrict_public_statuses = false
+    
+    begin
+      yield
+    ensure
+      Setting.restrict_public_statuses = original_setting
+    end
+  end
+  
+  # Temporarily enable visibility restrictions for a block (useful in test env)
+  def with_visibility_restrictions(&block)
+    original_setting = Setting.restrict_public_statuses
+    Setting.restrict_public_statuses = true
+    
+    begin
+      yield
+    ensure
+      Setting.restrict_public_statuses = original_setting
+    end
+  end
+end
+
+RSpec.configure do |config|
+  config.include StatusVisibilityHelpers
+end


### PR DESCRIPTION
Implement a configuration-driven status visibility policy to reduce merge conflicts and enable CI for the Mastodon fork.

The previous hard-coded validation in `app/models/concerns/status/visibility.rb` caused frequent merge conflicts with upstream updates and prevented CI from running due to widespread test failures. This PR refactors the restriction into a `StatusVisibilityPolicy` class, controlled by `config/settings.yml`, allowing the test environment to disable the restriction for upstream compatibility while maintaining the custom behavior in production. New helper scripts and documentation are also included to streamline fork management.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc37ccee-b605-48b9-a16f-c8666e622c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cc37ccee-b605-48b9-a16f-c8666e622c29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

