### PR TITLE
Rework expiring s3 urls for media attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,23 +4,21 @@
 
 An opinionated fork of mastodon with the following modifications:
 
-* All accounts are locked/private, meaning content is only distributed to followers [jesseplusplus/decodon#1](https://github.com/jesseplusplus/decodon/pull/1)
+- All accounts are locked/private, meaning content is only distributed to followers [jesseplusplus/decodon#1](https://github.com/jesseplusplus/decodon/pull/1)
 
-* Support for push notifications to Expo-based apps [jesseplusplus/decodon#2](https://github.com/jesseplusplus/decodon/pull/2)
+- Support for push notifications to Expo-based apps [jesseplusplus/decodon#2](https://github.com/jesseplusplus/decodon/pull/2)
 
-* Pre-signed URLs for extra-secure storage of uploaded private media [jesseplusplus/decodon#9](https://github.com/jesseplusplus/decodon/pull/9)
+- replies are treated more like comments and are filtered from the home feed [jesseplusplus/decodon#3](https://github.com/jesseplusplus/decodon/pull/3)
 
-* replies are treated more like comments and are filtered from the home feed [jesseplusplus/decodon#3](https://github.com/jesseplusplus/decodon/pull/3)
+- circles (lists of followers you can address posts to instead of only followers) - cherry-picked from [fedibird](https://github.com/fedibird/mastodon) - [jesseplusplus/decodon#13](https://github.com/jesseplusplus/decodon/pull/13)
 
-* circles (lists of followers you can address posts to instead of only followers) - cherry-picked from [fedibird](https://github.com/fedibird/mastodon) - [jesseplusplus/decodon#13](https://github.com/jesseplusplus/decodon/pull/13)
+- default "inner circle" for all accounts to get them started - [jesseplusplus/decodon#14](https://github.com/jesseplusplus/decodon/pull/14)
 
-* default "inner circle" for all accounts to get them started - [jesseplusplus/decodon#14](https://github.com/jesseplusplus/decodon/pull/14)
+- timeline markers for accounts' feed of updates - [jesseplusplus/decodon#189](https://github.com/jesseplusplus/decodon/pull/189)
 
-* timeline markers for accounts' feed of updates - [jesseplusplus/decodon#189](https://github.com/jesseplusplus/decodon/pull/189)
+- more control over logo and branding in email templates [jesseplusplus/decodon#10](https://github.com/jesseplusplus/decodon/pull/10)
 
-* more control over logo and branding in email templates [jesseplusplus/decodon#10](https://github.com/jesseplusplus/decodon/pull/10)
-
-* updated heroku deployment configs
+- updated heroku deployment configs
 
 ## Use
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ An opinionated fork of mastodon with the following modifications:
 
 - Support for push notifications to Expo-based apps [jesseplusplus/decodon#2](https://github.com/jesseplusplus/decodon/pull/2)
 
+- Signed URLs for extra-secure storage of uploaded private media [jesseplusplus/decodon#9](https://github.com/jesseplusplus/decodon/pull/9) [jesseplusplus/decodon#199](https://github.com/jesseplusplus/decodon/pull/199)
+
 - replies are treated more like comments and are filtered from the home feed [jesseplusplus/decodon#3](https://github.com/jesseplusplus/decodon/pull/3)
 
 - circles (lists of followers you can address posts to instead of only followers) - cherry-picked from [fedibird](https://github.com/fedibird/mastodon) - [jesseplusplus/decodon#13](https://github.com/jesseplusplus/decodon/pull/13)

--- a/app/controllers/media_proxy_controller.rb
+++ b/app/controllers/media_proxy_controller.rb
@@ -35,7 +35,8 @@ class MediaProxyController < ApplicationController
     media_token = MediaToken.find(params[:id])
     @media_attachment = media_token.media_attachment
 
-    redirect_to full_asset_url(@media_attachment.file.url(:original))
+    s3_url = @media_attachment.file.url(:original, expires_in: 15.minutes.to_i)
+    redirect_to s3_url, allow_other_host: true, status: 307
   end
 
   private

--- a/config/initializers/paperclip.rb
+++ b/config/initializers/paperclip.rb
@@ -121,11 +121,10 @@ if ENV['S3_ENABLED'] == 'true'
       module S3SignedExtensions
         def url(style_name = default_style, options = {})
           if path(style_name)
-            base_options = { expires_in: 1.week.to_i, time: Date.current.beginning_of_week.to_time }
             s3_url = "#{ENV['S3_BUCKET']}.s3.#{ENV['S3_REGION']}.amazonaws.com"
             s3_object(style_name).presigned_url(
               :get,
-              base_options.merge(s3_url_options)
+              options.merge(s3_url_options)
             ).to_s&.gsub(s3_url, ENV['S3_ALIAS_HOST'])
           else
             super


### PR DESCRIPTION
Expiring signed urls for media attachments were added in #9 as a potential way to secure media for private posts, but this scheme does not play well on its own with federation since remote servers do not refetch a new url when the old one expires. Since the first implementation, the media proxy has been added.

This PR:
* removes the default 7 day `expires_in` option when getting any paperclip attachment url (while continuing to sign the url with the default s3 expiration)
* moves the `expires_in` option to the media proxy and sets it for a shorter duration of 15 minutes
* updates the way the media proxy redirects so that the s3 urls don't get cached and can be regenerated when there is a refetch