### PR TITLE
Fix null context from missing parent status on new statuses

### DIFF
--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -453,8 +453,7 @@ class Status < ApplicationRecord
       self.in_reply_to_account_id = carried_over_reply_to_account_id
       self.conversation_id        = thread.conversation_id if conversation_id.nil?
     elsif conversation_id.nil?
-      conversation = build_owned_conversation
-      self.conversation = conversation
+      build_owned_conversation
     end
   end
 


### PR DESCRIPTION
After merging the upstream implementation of FEP-7888 included in the 4.5 release, contexts began appearing as null for new statuses because the `parent_status_id` was not being set. This PR puts back the previous working implementation from #188 to set conversation and parent status properly when creating a new status.